### PR TITLE
Add error messages only if payload data exists

### DIFF
--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -77,7 +77,7 @@ function getJob(options, callback) {
         if (res.statusCode !== 200 || payload.data.status === 'FAILED') {
             error = new Error('Job Failed');
             error.name = "JobCompletionStatusCheckError";
-            error.messages = payload.data.errors
+            if (payload && payload.data) error.messages = payload.data.errors;
             return callback(error);
         }
 


### PR DESCRIPTION
#### What?

When a job fails with a status code not equal to 200, its payload data doesn't exist. Error messages now only get set when payload data exists.
